### PR TITLE
Stopping the smooth transition when snap mode is DontSnap which cause…

### DIFF
--- a/Runtime/Scripts/Manipulation/UxrGrabbableObject.cs
+++ b/Runtime/Scripts/Manipulation/UxrGrabbableObject.cs
@@ -979,7 +979,7 @@ namespace UltimateXR.Manipulation
             UxrGrabPointInfo grabPointInfo = GetGrabPoint(grabPoint);
             Transform        snapTransform = GetGrabPointGrabAlignTransform(grabber.Avatar, grabPoint, grabber.Side);
 
-            if (snapTransform == null || grabPointInfo == null)
+            if (snapTransform == null || grabPointInfo == null || grabPointInfo.SnapMode == UxrSnapToHandMode.DontSnap)
             {
                 return false;
             }


### PR DESCRIPTION
Stopping the smooth transition of the hand when snap mode is set to DontSnap, it is unnecessary and caused the hand to twitch randomly when releasing the object