### PR TITLE
Added binding for rare occasion when Quest 2 gets incorrectly identified as Standalone HMD

### DIFF
--- a/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest2Input.cs
+++ b/Runtime/Scripts/Devices/Integrations/Meta/UxrMetaTouchQuest2Input.cs
@@ -61,7 +61,8 @@ namespace UltimateXR.Devices.Integrations.Meta
             get
             {
                 if (UxrTrackingDevice.HeadsetDeviceName is "Quest 2" ||
-                    UxrTrackingDevice.HeadsetDeviceName is "Oculus Quest2")
+                    UxrTrackingDevice.HeadsetDeviceName is "Oculus Quest2" ||
+                    UxrTrackingDevice.HeadsetDeviceName is "Standalone HMD")
                 {
                     yield return "Oculus Touch Controller - Left";
                     yield return "Oculus Touch Controller - Right";


### PR DESCRIPTION
Added binding for rare occasion when Quest 2 gets incorrectly identified as Standalone HMD on some devices.