### PR TITLE
Fix for finishedCallback being called too soon when teleporting with fade

### DIFF
--- a/Runtime/Scripts/Core/UxrManager.cs
+++ b/Runtime/Scripts/Core/UxrManager.cs
@@ -426,11 +426,8 @@ namespace UltimateXR.Core
 
             Vector3    newRelativeFloorPosition = referenceTransform != null ? referenceTransform.InverseTransformPoint(newFloorPosition) : newFloorPosition;
             Quaternion newRelativeRotation      = referenceTransform != null ? Quaternion.Inverse(referenceTransform.rotation) * newRotation : newRotation;
-            bool       hasFinished              = false;
 
-            _teleportCoroutine = StartCoroutine(TeleportLocalAvatarRelativeCoroutine(referenceTransform, parentToReference, newRelativeFloorPosition, newRelativeRotation, translationType, transitionSeconds, teleportedCallback, () => hasFinished = true, propagateEvents));
-
-            finishedCallback?.Invoke(hasFinished);
+            _teleportCoroutine = StartCoroutine(TeleportLocalAvatarRelativeCoroutine(referenceTransform, parentToReference, newRelativeFloorPosition, newRelativeRotation, translationType, transitionSeconds, teleportedCallback, () => finishedCallback?.Invoke(true), propagateEvents));
         }
 
         /// <summary>


### PR DESCRIPTION
Callback was called with false immediately after the coroutine started, and never again, rather than when the coroutine completed as expected