### PR TITLE
Made NotifyTeleportSpawnCollider overridable

### DIFF
--- a/Runtime/Scripts/Locomotion/UxrTeleportLocomotionBase.cs
+++ b/Runtime/Scripts/Locomotion/UxrTeleportLocomotionBase.cs
@@ -823,7 +823,7 @@ namespace UltimateXR.Locomotion
         ///     Notifies a change in the currently targeted <see cref="UxrTeleportSpawnCollider" /> component.
         /// </summary>
         /// <param name="teleportSpawnCollider">New currently targeted component or null if none is selected</param>
-        private void NotifyTeleportSpawnCollider(UxrTeleportSpawnCollider teleportSpawnCollider)
+        protected virtual void NotifyTeleportSpawnCollider(UxrTeleportSpawnCollider teleportSpawnCollider)
         {
             if (teleportSpawnCollider && teleportSpawnCollider.enabled)
             {
@@ -1030,6 +1030,15 @@ namespace UltimateXR.Locomotion
                 }
             }
         }
+        /// <summary>
+        /// Gets the current teleport target <see cref="UxrTeleportTarget" /> .
+        /// </summary>
+        protected UxrTeleportTarget TeleportTarget => _teleportTarget;
+        
+        /// <summary>
+        /// Gets the current teleport spawn collider <see cref="UxrTeleportSpawnCollider" /> .
+        /// </summary>
+        protected UxrTeleportSpawnCollider LastSpawnCollider => _lastSpawnCollider;
 
         #endregion
 


### PR DESCRIPTION
- [x] My branch name contains the Jira Ticket Id in line with our source control practices.

# Description

Made NotifyTeleportSpawnCollider overridable so inheriting OmsTeleportLocomotion can override to handle showing and hiding teleport location spots.

## Type of change

Tick the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Potentially Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Risk
- [ ] Are these changes likely to introduce unforeseen consequences? If yes what has been done to mitigate that?

# How Has This Been Tested?

Please state how you tested to verify your changes. 

- [ ] Introduced Automated Tests ( if not why not i.e. code is still too tightly coupled and would require changes beyond the scope of this work )
- [x] Manual Testing ( please detail testing and include relevant screen shots or videos )
Manually tested in the Unity editor, Windows build + Quest 3 tethered and Quest 3 standalone.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation where applicable
- [x] My changes generate no new warnings
- [x] I have limited the scope of my changes to be only relevant to the issue/bug
