### PR TITLE
Bug 6979: added button threshold variable

### DIFF
--- a/Runtime/Scripts/Devices/Integrations/Pico/UxrPicoNeo3Input.cs
+++ b/Runtime/Scripts/Devices/Integrations/Pico/UxrPicoNeo3Input.cs
@@ -15,6 +15,12 @@ namespace UltimateXR.Devices.Integrations.Pico
     {
         #region Public Overrides UxrControllerInput
 
+        protected override void Awake()
+        {
+            base.Awake();
+            ButtonPressThreshold = 0.71f;
+        }
+
         /// <summary>
         ///     Gets the SDK dependency: PicoXR.
         /// </summary>

--- a/Runtime/Scripts/Devices/Integrations/UxrUnityXRControllerInput.cs
+++ b/Runtime/Scripts/Devices/Integrations/UxrUnityXRControllerInput.cs
@@ -833,7 +833,7 @@ namespace UltimateXR.Devices.Integrations
                 if (inputDevice.TryGetFeatureValue(CommonUsages.trigger, out float valueFloat))
                 {
                     // We try getting the float value first because in analog buttons like the oculus it will trigger too early with the bool version.
-                    return valueFloat > AnalogAsDPadThreshold;
+                    return valueFloat > ButtonPressThreshold;
                 }
 
                 if (inputDevice.TryGetFeatureValue(CommonUsages.triggerButton, out bool value))

--- a/Runtime/Scripts/Devices/UxrControllerInput.cs
+++ b/Runtime/Scripts/Devices/UxrControllerInput.cs
@@ -1500,7 +1500,7 @@ namespace UltimateXR.Devices
         /// <summary>
         ///     Minimum button press pressure required on trigger to act as a button 
         /// </summary>
-        protected const float ButtonPressThreshold = 0.5f;
+        protected float ButtonPressThreshold = 0.5f;
 
         /// <summary>
         ///     Default haptic amplitude if not specified

--- a/Runtime/Scripts/Devices/UxrControllerInput.cs
+++ b/Runtime/Scripts/Devices/UxrControllerInput.cs
@@ -1496,6 +1496,11 @@ namespace UltimateXR.Devices
         ///     Minimum axis value required to consider an analog input as a DPad digital press in any direction.
         /// </summary>
         protected const float AnalogAsDPadThreshold = 0.2f;
+        
+        /// <summary>
+        ///     Minimum button press pressure required on trigger to act as a button 
+        /// </summary>
+        protected const float ButtonPressThreshold = 0.5f;
 
         /// <summary>
         ///     Default haptic amplitude if not specified


### PR DESCRIPTION
- [x] My branch name contains the Jira Ticket Id in line with our source control practices.

# Description

https://oxfordmedicalsimulation.atlassian.net/browse/BUG-6979
Changed the input button threshold to be editable by implementation classes, and make more sense than using the D pad input. 
Updated the Pico to take into account it's 'differences' from quest default. 

## Type of change

Tick the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Potentially Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Risk

<!-- - [ ] Do these changes require [Change Board Approval](https://oxfordmedicalsimulation.atlassian.net/wiki/spaces/CAB/pages/1429635073/Changes+that+require+CAB+approval)? -->
- [ ] Are these changes likely to introduce unforeseen consequences? If yes what has been done to mitigate that?

# How Has This Been Tested?

Please state how you tested to verify your changes. 

- [ ] Introduced Automated Tests ( if not why not i.e. code is still too tightly coupled and would require changes beyond the scope of this work )
- [x] Manual Testing ( please detail testing and include relevant screen shots or videos )
Unity Editor VR, 
Quest 3S, 
Pico 4 Ultra Express Enterprise Ultimate. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation where applicable
- [x] My changes generate no new warnings
- [x] I have limited the scope of my changes to be only relevant to the issue/bug
